### PR TITLE
remove deprecated parameter has_rdoc from propay.gemspec

### DIFF
--- a/propay.gemspec
+++ b/propay.gemspec
@@ -23,5 +23,4 @@ HERE
 
   gem.license = "MIT"
   gem.extra_rdoc_files = ["README.md", "ChangeLog"]
-  gem.has_rdoc = false
 end


### PR DESCRIPTION
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/bundle/bundler/gems/propay-8811197f0267/propay.gemspec:26.
```